### PR TITLE
syntax fix

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -72,7 +72,7 @@ potential_bin_dirs=( \
   /usr/local/google-cloud-sdk/bin \
 )
 for potential_bin_dir in "${potential_bin_dirs[@]}"; do
-  if [[ -d "$potential_bin_dir" ]] && !(echo $PATH | grep "$potential_bin_dir" &>/dev/null); then
+  if [[ -d "$potential_bin_dir" ]] && ! echo $PATH | grep "$potential_bin_dir" &>/dev/null; then
     export PATH=$PATH:$potential_bin_dir
   fi
 done


### PR DESCRIPTION
https://github.com/cisco-sso/ansible-role-k8s-devkit/pull/6

The `!` requires a space from both sides. Also there is no need to execute the command in a subshell, operator precedence works well between pipe `|` and exit code negation `!`
http://tldp.org/LDP/abs/html/opprecedence.html

ptal @dcwangmit01 @simt2 @marsavela