### PR TITLE
Source `.bashrc` if present

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -147,3 +147,11 @@ fi
 if [[ -n ${PS1:-''} ]] && which kops &>/dev/null; then
     source <(kops completion bash)
 fi
+
+#####################################################################
+# Load .bashrc if present
+
+if [[ -f .bashrc ]]; then
+    source .bashrc
+fi
+


### PR DESCRIPTION
Not sourcing `.bashrc` (when present) breaks all the default aliases (and
skips color schemes) in Ubuntu distro